### PR TITLE
removed dashboard from student page

### DIFF
--- a/Sharky/src/pages/Homepage.js
+++ b/Sharky/src/pages/Homepage.js
@@ -38,9 +38,6 @@ const Homepage = () => {
           <Link to="/logout" className="menu-btn">
             Logout
           </Link>
-          <Link to="/Dashboard" className="menu-btn">
-            dashboard check
-          </Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
#42 
The dashboard that was added to the student homepage for practice is now deleted and it is only accessible through instructor page.