### PR TITLE
Adding Date/Time component to the Dashboard page

### DIFF
--- a/Sharky/src/App.js
+++ b/Sharky/src/App.js
@@ -122,6 +122,14 @@ const App = () => {
           </Layout>
         }
       />
+<Route
+        path="/Dashboard"
+        element={
+          <Layout>
+            <Dashboard />
+          </Layout>
+        }
+      />
 
       {/* Protected Routes */}
 


### PR DESCRIPTION
This pull request is solving issue https://github.com/flyingbearxx/SHARKY-SOEN341_Project_F24/issues/71. Now the Date/Time component is shown on all pages for both students and teachers including dashboard page. 